### PR TITLE
kitsune v1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ K-mer based approach is simple and fast yet has been widely used in many applica
 KITSUNE will calculte the three matrices across considered k-mer range:
 
 1. Cumulative Relative Entropy (CRE)
-1. Averrage number of Common Feature (ACF)
-1. Obserbed Common Feature (OCF)
+1. Average number of Common Features (ACF)
+1. Observed Common Features (OCF)
 
 Moreover, KITSUNE also provides various genomic distance calculations from the k-mer frequency vectors that can be used for species identification or phylogenomic tree construction.  
 
@@ -61,7 +61,7 @@ $ kitsune --help
 usage: kitsune <command> [<args>]
 
 Available commands:
-  acf      Compute average number of common feature between signatures
+  acf      Compute average number of common features between signatures
   cre      Compute cumulative relative entropy
   dmatrix  Compute distance matrix
   kopt     Compute recommended choice (optimal) of kmer within a given kmer interval for a set of genomes using the cre, acf and ofc
@@ -108,7 +108,7 @@ usage: kitsune (acf) [-h] --filenames FILENAMES [FILENAMES ...] [--fast]
                      [--canonical] -k KMERS [KMERS ...] [-t THREAD]
                      [-o OUTPUT]
 
-Calculate an average number of common feature pairwise between one genome
+Calculate an average number of common features pairwise between one genome
 against others
 
 optional arguments:
@@ -152,7 +152,7 @@ optional arguments:
 #### General Example
 
 ```bash
-kitsune cre --filenames genome1.fna -kf 5 -ke 10
+kitsune cre --filename genome1.fna -kf 5 -ke 10
 kitsune acf --filenames genome1.fna genome2.fna -k 5
 kitsune ofc --filenames genome_fasta/* -k 5
 ```
@@ -234,42 +234,45 @@ Kitsune provides a wrap-up comand to find optimum k-mer length for a given set o
 ```bash
 $ kitsune kopt -h
 
-usage: kitsune (ofc) [-h] --filenames FILENAMES [--fast] [--canonical] -kl
-                     KLARGE [-o OUTPUT] [--closely_related] [-x CRE_CUTOFF]
-                     [-y ACF_CUTOFF] [-t THREAD] [-n NPROC]
+usage: kitsune (kopt) [-h] [--acf-cutoff ACF_CUTOFF] [--canonical]
+                      [--closely-related] [--cre-cutoff CRE_CUTOFF] [--fast]
+                      --filenames FILENAMES [--hashsize HASHSIZE]
+                      [--in-memory] [--k-min K_MIN] --k-max K_MAX
+                      [--lower LOWER] [--nproc NPROC] [--output OUTPUT]
+                      [--threads THREADS]
 
-Find the recommended optimal kmer using acf,cre and ofc for a given set of
-genomes. Example: kitsune kopt genomeList.txt -kl 15 --canonical --fast -t 4
--o out.txt
+Optimal kmer size selection for a set of genomes using Average number of
+Common Features (ACF), Cumulative Relative Entropy (CRE), and Observed Common
+Features (OCF). Example: kitsune kopt --filenames genomeList.txt --k-min 4
+--k-max 12 --canonical --fast
 
 optional arguments:
   -h, --help            show this help message and exit
-  --filenames FILENAMES
-                        A file that list the path to all genomes (fasta
-                        format) with extension as (.txt, .csv, .tab) or no
-                        extension (default: None)
+  --acf-cutoff ACF_CUTOFF
+                        Cutoff to use in selecting kmers whose ACFs are >=
+                        (cutoff * max(ACF)) (default: 0.1)
+  --canonical           Jellyfish count only canonical kmers (default: False)
+  --closely-related     Use in case of closely related genomes (default:
+                        False)
+  --cre-cutoff CRE_CUTOFF
+                        Cutoff to use in selecting kmers whose CREs are <=
+                        (cutoff * max(CRE)) (default: 0.1)
   --fast                Jellyfish one-pass calculation (faster) (default:
                         False)
-  --canonical           Jellyfish count only canonical mer (default: False)
-  -kl KLARGE, --klarge KLARGE
-                        Largest k-mer length to consider, note: the smallest
-                        kmer length is 4 (default: None)
-  -o OUTPUT, --output OUTPUT
-                        Output filename (default: None)
-  --closely_related     For closely related set of genomes, use this option
-                        (default: False)
-  -x CRE_CUTOFF, --cre_cutoff CRE_CUTOFF
-                        Cutoff to use in selecting kmers whose cre's are <=
-                        (cutoff * max(cre)), Default = 10 percent, ie x=0.1
-                        (default: 0.1)
-  -y ACF_CUTOFF, --acf_cutoff ACF_CUTOFF
-                        Cutoff to use in selecting kmers whose acf's are >=
-                        (cutoff * max(acf)), Default = 10 percent, ie y=0.1
-                        (default: 0.1)
-  -t THREAD, --thread THREAD
-                        Number of threads (default: 1)
-  -n NPROC, --nproc NPROC
-                        Number of processes (default: 1)
+  --filenames FILENAMES
+                        Path to the file with the list of genome files paths.
+                        There should be at list 2 input genomes (default:
+                        None)
+  --hashsize HASHSIZE   Jellyfish initial hash size (default: 100M)
+  --in-memory           Keep Jellyfish counts in memory (default: False)
+  --k-min K_MIN         Minimum kmer size (default: 4)
+  --k-max K_MAX         Maximum kmer size (default: None)
+  --lower LOWER         Do not let Jellyfish output kmers with count < --lower
+                        (default: 1)
+  --nproc NPROC         Maximum number of CPUs to make it parallel (default:
+                        1)
+  --output OUTPUT       Path to the output file (default: None)
+  --threads THREADS     Maximum number of threads for Jellyfish (default: 1)
 ```
 
 ### Example dataset
@@ -277,7 +280,7 @@ optional arguments:
 First download the example files. [Download](examples/example_viral_genomes.zip)
 
 ```bash
-kitsune kopt --filenames genome_list -kl 15 --canonical --fast -t 4 -n 1 -o out.txt
+kitsune kopt --filenames genome_list --k-min 6 --k-max 21 --canonical --fast --threads 4 --nproc 2 --output out.txt
 ```
 
 > :warning: _Please be aware that this command will use big computational resources when large number of genomes and/or large genome size are used as the input._

--- a/kitsune/kitsune.py
+++ b/kitsune/kitsune.py
@@ -7,12 +7,12 @@ import importlib
 import sys
 
 __author__ = "Natapol Pornputtapong (natapol.p@chula.ac.th)"
-__version__ = "1.3.2"
-__date__ = "Feb 13, 2023"
+__version__ = "1.3.3"
+__date__ = "Mar 15, 2023"
 
 # Define the set of commands with help messages
 COMMANDS = {
-    "acf": "Compute average number of common feature between signatures",
+    "acf": "Compute average number of common features between signatures",
     "cre": "Compute cumulative relative entropy",
     "dmatrix": "Compute distance matrix",
     "kopt": ("Compute recommended choice (optimal) of kmer within a given "

--- a/kitsune/modules/acf.py
+++ b/kitsune/modules/acf.py
@@ -1,4 +1,6 @@
 import argparse as ap
+import sys
+from operator import itemgetter
 
 from tqdm import tqdm
 
@@ -94,15 +96,9 @@ def run(args):
 
     outdata = cal_acf(args.filenames, **vars(args))
     outdata = sorted(outdata.items(), key=itemgetter(0))
-    
-    if args.output is not None:
-        with open(args.output, 'w+') as ofhandle:
-            for data in outdata:
-                ofhandle.write("{}\n".format("\t".join([str(x) for x in data])))
-    
-    else:
-        for data in outdata:
-            print("{}".format("\t".join([str(x) for x in data])))
+    outdata = '\n'.join(['\t'.join([str(x) for x in data]) for data in outdata])
+
+    print(outdata, file=open(args.output, "w+") if args.output else None)
 
 
 if __name__ == "__main__":

--- a/kitsune/modules/cre.py
+++ b/kitsune/modules/cre.py
@@ -1,5 +1,7 @@
 import argparse as ap
 import math
+import sys
+from operator import itemgetter
 
 from tqdm import tqdm
 
@@ -92,9 +94,9 @@ def cal_re(a0, a1, a2):
     
     for key in a0.keys():
         realf = a0[key]
-        left = a1[key[0:-1]]
-        right = a1[key[1:]]
-        below = a2[key[1:-1]]
+        left = a1[key[:-1]] if key[:-1] in a1 else 0
+        right = a1[key[1:]] if key[1:] in a1 else 0
+        below = a2[key[1:-1]] if key[1:-1] in a2 else 0
         
         if 0 not in (left, right, below):
             expectf = left * right / below
@@ -114,15 +116,8 @@ def run(args):
     outdata = cal_cre(args.filename, **vars(args))
     outdata = sorted(outdata.items(), key=itemgetter(0))
     outdata = '\n'.join(['\t'.join([str(x) for x in data]) for data in outdata])
-    
-    if args.output is not None:
-        with open(args.output, 'w') as ofhandle:
-            for data in outdata:
-                ofhandle.write("{}\n".format("\t".join([str(x) for x in data])))
-    
-    else:
-        for data in outdata:
-            print("{}".format("\t".join([str(x) for x in data])))
+
+    print(outdata, file=open(args.output, "w+") if args.output else None)
 
 
 if __name__ == "__main__":

--- a/kitsune/modules/dmatrix.py
+++ b/kitsune/modules/dmatrix.py
@@ -1,6 +1,7 @@
 import argparse as ap
 import collections
 import json
+import sys
 from operator import attrgetter
 
 from tqdm import tqdm
@@ -88,13 +89,8 @@ def run(args):
     
     else:
         outdata = json.dumps(outdata, indent=2)
-        
-    if args.output is not None:
-        with open(args.output, 'w') as ofhandle:
-            ofhandle.write(outdata)
-    
-    else:
-        print(outdata)
+
+    print(outdata, file=open(args.output, "w+") if args.output else None)
 
 
 if __name__ == "__main__":

--- a/kitsune/modules/kitsunejf.py
+++ b/kitsune/modules/kitsunejf.py
@@ -1,4 +1,3 @@
-import collections
 import errno
 import math
 import os
@@ -164,7 +163,7 @@ PROB_DISTANCE = [
 ]
 
 
-class Kmercount(collections.Counter):
+class Kmercount(dict):
 
     def __init__(self, fsa, k_mer, **karg):
         self.kmer = k_mer
@@ -197,12 +196,11 @@ class Kmercount(collections.Counter):
             if 'fast' in karg and karg['fast']:
                 # for genome with one step
                 dumpdata = subprocess.getoutput("""
-                    {0} count {8} -m {1} -s {3} -t {4} -o {5}.jf {6}
-                    {0} dump -c -L {7} {5}.jf
+                    {0} count {7} -L {6} -m {1} -s {2} -t {3} -o {4}.jf {5}
+                    {0} dump -c -L {6} {4}.jf
                     """.format(
                         "jellyfish",
                         self.kmer,
-                        karg['bchashsize'],
                         karg['hashsize'],
                         karg['thread'],
                         os.path.join(tmpdirname, filebasename),
@@ -215,7 +213,7 @@ class Kmercount(collections.Counter):
             else:
                 dumpdata = subprocess.getoutput("""
                     {0} bc {8} -m {1} -s {2} -t {4} -o {5}.bc {6}
-                    {0} count {8} -m {1} -s {3} -t {4} --bc {5}.bc -o {5}.jf {6}
+                    {0} count {8} -L {7} -m {1} -s {3} -t {4} --bc {5}.bc -o {5}.jf {6}
                     {0} dump -c -L {7} {5}.jf
                     """.format(
                         "jellyfish",

--- a/kitsune/modules/kopt.py
+++ b/kitsune/modules/kopt.py
@@ -1,17 +1,24 @@
+#!/usr/bin/env python3
+"""
+Optimal kmer size selection for a set of genomes using Average number of Common Features (ACF),
+Cumulative Relative Entropy (CRE), and Observed Common Features (OCF)
+"""
+
 import argparse as ap
 import collections
+import errno
 import math
 import multiprocessing as mp
 import os
+import sys
 import time
+from functools import partial
+from itertools import chain, combinations
+from operator import itemgetter
+from typing import Dict, List, Optional, Tuple
 
-from collections import Counter
-from itertools import combinations, chain, islice
-from operator import itemgetter, attrgetter
-
-import numpy as np
-
-from tqdm import tqdm
+import numpy as np  # type: ignore
+import tqdm  # type: ignore
 
 from kitsune.modules import kitsunejf as jf
 
@@ -24,377 +31,661 @@ def read_params(args):
     """
 
     p = ap.ArgumentParser(
-        prog="kitsune (ofc)",
+        prog="kitsune (kopt)",
         description=(
-            "Find the recommended optimal kmer using acf,cre and ofc for a given set of genomes. "
-            "Example: kitsune kopt genomeList.txt -kl 15 --canonical --fast -t 4 -o out.txt"
+            "Optimal kmer size selection for a set of genomes using Average number of Common Features (ACF), "
+            "Cumulative Relative Entropy (CRE), and Observed Common Features (OCF). "
+            "Example: kitsune kopt --filenames genomeList.txt --k-min 4 --k-max 12 --canonical --fast"
         ),
-        formatter_class=ap.ArgumentDefaultsHelpFormatter,
+        formatter_class=ap.ArgumentDefaultsHelpFormatter
+    )
+    p.add_argument(
+        "--acf-cutoff",
+        type=float,
+        default=0.1,
+        dest="acf_cutoff",
+        help="Cutoff to use in selecting kmers whose ACFs are >= (cutoff * max(ACF))"
+    )
+    p.add_argument(
+        "--canonical",
+        action="store_true",
+        default=False,
+        help="Jellyfish count only canonical kmers"
+    )
+    p.add_argument(
+        "--closely-related",
+        action="store_true",
+        default=False,
+        dest="closely_related",
+        help="Use in case of closely related genomes"
+    )
+    p.add_argument(
+        "--cre-cutoff",
+        type=float,
+        default=0.1,
+        dest="cre_cutoff",
+        help="Cutoff to use in selecting kmers whose CREs are <= (cutoff * max(CRE))"
+    )
+    p.add_argument(
+        "--fast",
+        action="store_true",
+        default=False,
+        help="Jellyfish one-pass calculation (faster)"
     )
     p.add_argument(
         "--filenames",
-        type=valid_file,
+        type=os.path.abspath,
         required=True,
-        help="A file that list the path to all genomes (fasta format) with extension as (.txt, .csv, .tab) or no extension"
+        help=(
+            "Path to the file with the list of genome files paths. "
+            "There should be at list 2 input genomes"
+        )
     )
-    p.add_argument("--fast", action='store_true', help="Jellyfish one-pass calculation (faster)")
-    p.add_argument("--canonical", action='store_true', help="Jellyfish count only canonical mer")
     p.add_argument(
-        "-kl",
-        "--klarge",
+        "--hashsize",
+        type=str,
+        default="100M",
+        help="Jellyfish initial hash size"
+    )
+    p.add_argument(
+        "--in-memory",
+        action="store_true",
+        default=False,
+        dest="in_memory",
+        help="Keep Jellyfish counts in memory"
+    )
+    p.add_argument(
+        "--k-min",
         type=int,
+        default=4,
+        dest="k_min",
+        help="Minimum kmer size"
+    )
+    p.add_argument(
+        "--k-max",
+        type=int,
+        dest="k_max",
         required=True,
-        help="Largest k-mer length to consider, note: the smallest kmer length is 4"
-    )
-    p.add_argument("-o", "--output", type=str, help="Output filename")
-    p.add_argument("--closely_related", action='store_true', help="For closely related set of genomes, use this option" )
-    p.add_argument(
-        "-x",
-        "--cre_cutoff",
-        type=number,
-        default=0.1,
-        help="Cutoff to use in selecting kmers whose cre's are <= (cutoff * max(cre)), Default = 10 percent, ie x=0.1"
+        help="Maximum kmer size"
     )
     p.add_argument(
-        "-y",
-        "--acf_cutoff",
-        type=number,
-        default=0.1,
-        help="Cutoff to use in selecting kmers whose acf's are >= (cutoff * max(acf)), Default = 10 percent, ie y=0.1"
+        "--lower",
+        type=int,
+        default=1,
+        help="Do not let Jellyfish output kmers with count < --lower"
     )
-    p.add_argument("-t", "--thread", type=int, default=1, help="Number of threads")
-    p.add_argument("-n", "--nproc", type=int, default=1, help="Number of processes")
+    p.add_argument(
+        "--nproc",
+        type=int,
+        default=1,
+        help="Maximum number of CPUs to make it parallel"
+    )
+    p.add_argument(
+        "--output",
+        type=os.path.abspath,
+        help="Path to the output file"
+    )
+    p.add_argument(
+        "--threads",
+        type=int,
+        default=1,
+        help="Maximum number of threads for Jellyfish"
+    )
     return p.parse_args(args)
 
 
-def valid_file(filepath):
-    _, ext = os.path.splitext(filepath)
-    
-    if ext.lower() not in ('.csv', '.tab', '.txt', ''):
-        raise argparse.ArgumentTypeError('File must have a csv, txt, tab extension or no extension')
-    
-    return filepath
-
-
-def number(value):
-    try:
-        value = float(value)
-
-    except ValueError:
-        raise argparse.ArgumentTypeError("%r not a floating-point literal" % (value,))
-
-    if value < 0.0 or value > 1.0:
-        raise argparse.ArgumentTypeError("%r not in range [0.0, 1.0]" % (value,))
-
-    return value
-
-
-def cal_cre(fsa, kl, **karg):
-    """ Calculate Cumulative Relative Entropy (CRE)
-        CRE = sum(RE from kmer to infinite)
-    Args:
-        fsa genome file in fasta format
-        kend the infinite kmer
-        kfrom calculate to (defualt=4)
-
-    Returns: dict(kmer: CRE)
-
+def count_kmers(
+    genome: str,
+    kmin: int = 4,
+    kmax: int = 4,
+    fast: bool = False,
+    canonical: bool = False,
+    lower: int = 1,
+    hashsize: str = "100M",
+    threads: int = 1
+) -> Tuple[str, Dict[int, jf.Kmercount]]:
     """
-    ksmall = 4
-    klarge = kl
-    a0 = None
-    a1 = None
-    a2 = None
-    result = {}
-    for kmer in tqdm(range(klarge,ksmall-1,-1)):
-        if a0 is None:
-            a0 = jf.Kmercount(fsa, kmer, **karg)
-            a1 = jf.Kmercount(fsa, kmer - 1, **karg)
-            a2 = jf.Kmercount(fsa, kmer - 2, **karg)
-        else:
-            a0 = a1
-            a1 = a2
-            a2 = jf.Kmercount(fsa, kmer - 2, **karg)
-        if kmer + 1 in result:
-            result[kmer] = cal_re(a0, a1, a2) + result[kmer + 1]
-        else:
-            result[kmer] = cal_re(a0, a1, a2)
-    return result
+    Run Jellyfish for counting kmers over an interval of kmer sizes on a input genome
 
-
-def cal_re(a0, a1, a2):
-    """ Calculate Relative Entropy (RE)
-        f' = fl * fr / fb
-        example: f' of mer 'ATTTGCA' 
-                f  is frequency of ATTTGCA from a0
-                fl is frequency of ATTTGC- from a1
-                fr is frequency of -TTTGCA from a1
-                fb is frequency of -TTTGC- from a2
-        RE = f * log2(f/f')
-    Args:
-        a0 Kmercount kmer
-        a1 Kmercount kmer - 1
-        a2 Kmercount kmer - 2
-
-    Returns: float
-
+    :param genome:      Path to the input genome
+    :param kmin:        Minimum kmer size
+    :param kmax:        Maximum kmer size
+    :param fast:        Jellyfish one-pass calculation (faster)
+    :param canonical:   Jellyfish count only canonical kmers
+    :param lower:       Do not let Jellyfish output kmers with count < --lower
+    :param hashsize:    Jellyfish initial hash size
+    :param threads:     Make it parallel
+    :return:            Dictionary with the list of kmers per kmer size
     """
-    result = 0
-    rfactor = a0.sum
-    lfactor = math.log((a1.sum ** 2) / (a2.sum * rfactor), 2)
-    for key in a0.keys():
-        realf = a0[key]
-        left = a1[key[0:-1]]
-        right = a1[key[1:]]
-        below = a2[key[1:-1]]
-        if 0 not in (left, right, below):
-            expectf = left * right / below
-            result += max(0, realf / rfactor * (math.log(realf / expectf, 2) + lfactor))
-    return result
+
+    # Define a range of kmer sizes
+    kmer_sizes = list(range(kmin, kmax + 1))
+
+    datadict = dict()
+
+    for kmer in kmer_sizes:
+        datadict[kmer] = jf.Kmercount(
+            genome,
+            kmer,
+            thread=threads,
+            lower=lower,
+            hashsize=hashsize,
+            canonical=canonical,
+            fast=fast
+        )
+
+    return genome, datadict
 
 
-def cal_acf(fsas, klarge, **karg):
-    """Calculate Average number of common features (ACF)
-
-    Args:
-        fsas (str):  genome file name(s).
-        kmers (): a list of kmer to calculate.
-
-    Kwargs:
-        state (bool): Current state to be in.
-        thread (int): Number of thread to calculate default 1
-        lower (int): default 1
-        bchashsize (str): hashsize for jellyfish bc step default '1G'
-        hashsize (str): hashsize for jellyfish count step default '100M'
-        canonical (bool): set canonical calculation
-
-    Returns:
-        dict(kmer: acf)
-
-    Raises:
-        AttributeError, KeyError
-
-    A really great idea.  A way you might use me is
-
-    >>> print public_fn_with_googley_docstring(name='foo', state=None)
-    0
-
-    BTW, this always returns 0.  **NEVER** use with :class:`MyPublicClass`.
-
+def filter(n: List[str], m: int) -> List[int]: 
     """
-    ksmall = 4
-    n = len(fsas)
-    if n >= 2:
-        result = {}
-        for kmer in tqdm(range(ksmall, klarge+1)):
-            if kmer % 2 == 1:
-                keys_array = []
-                for fsa in fsas:
-                    keys_array.append(set(jf.Kmercount(fsa, kmer, **karg).keys()))
-                ccf = 0
-                for pri_idx, key in enumerate(keys_array):
-                    for sec_idx in range(pri_idx + 1, n):
-                        ccf += len(keys_array[pri_idx] & keys_array[sec_idx])
-                result[kmer] = ccf/(n-1)
-            else:
-                continue
-        return result
-    else:
-        raise
+    Filter a list based on the occurrences of values
 
-
-def cal_ofc(fsas, kmer, **karg):
-    """ Calculate shannon entropy of observed feature occurrences (OFC)
-        ofc(l) = -sum(p ln p)
-    Args:
-        fsa a genome file
-        k_mers a list of kmer to calculate
-
-    Returns: float shannon entropy
-
+    :param n:   Input list
+    :param m:   Filer factor
+    :return:    Filtered list
     """
-    result = {}
 
-    keys = []
-    if kmer % 2 == 1:
-        for fsa in fsas:
-            keys.extend(list(jf.Kmercount(fsa, kmer, **karg).keys()))
-
-        count_feature = list(collections.Counter((collections.Counter(keys).values())).values())
-        lnp = np.log2(count_feature) - (2 * kmer)
-        result[kmer] = np.sum(np.exp2(lnp) * lnp) * -1
-    return result
-
-
-def filter(n, m): 
-    c = Counter(n)
+    c = collections.Counter(n)
     cr = set(n)
-    result = []
-    
+    result = list()
+
     for i in cr:
         if c[i] >= int(m * 0.5):
             result.append(i)
-    
+
     return result
 
 
-def kopt_cre(l, kl, genomeList, args):
-    genome = genomeList[l]
-    outdata = cal_cre(genome, kl, **vars(args))
-    outdata = sorted(outdata.items(), key=itemgetter(0))
-    return outdata
-
-
-def kopt_acf(p,args): 
-    outdata_acf = cal_acf(p, **vars(args))
-    outdata_acf = sorted(outdata_acf.items(), key=itemgetter(0))
-    return outdata_acf
-
-
-def kopt_ofc(genomeList,kmer, args):
-    outdata_ofc = cal_ofc(genomeList,kmer, **vars(args))
-    outdata_ofc = sorted(outdata_ofc.items(), key=itemgetter(0))
-    return outdata_ofc
-
-
-def run(args):
+def par_acf(
+    genome1: str,
+    genome2: str,
+    kmin: Optional[int] = None,
+    kmax: Optional[int] = None,
+    counts: Optional[Dict[str, Dict[int, jf.Kmercount]]] = None,
+    fast: bool = False,
+    canonical: bool = False,
+    lower: int = 1,
+    hashsize: str = "100M",
+    threads: int = 1
+) -> List[Tuple[int, int]]:
     """
-    Find the recommended optimal kmer using acf,cre and ofc for a given set of genomes
+    Make the computation of ACF parallel
+    Run a instance of this function for each of the processes in a Pool
+
+    :param genome1:     Genome #1
+    :param genome2:     Genome #2
+    :param kmin:        Minimum kmer size
+    :param kmax:        Maximum kmer size
+    :param counts:      Kmer counts for the input genomes
+    :param fast:        Jellyfish one-pass calculation (faster)
+    :param canonical:   Jellyfish count only canonical kmers
+    :param lower:       Do not let Jellyfish output kmers with count < --lower
+    :param hashsize:    Jellyfish initial hash size
+    :param threads:     Maximum number of threads for Jellyfish
+    :return:            ACF
     """
+
+    res_acf = dict()
+
+    for kmer in range(kmin, kmax + 1):
+        if not counts:
+            count_kmers_partial = partial(
+                count_kmers,
+                kmin=kmer,
+                kmax=kmer,
+                fast=fast,
+                canonical=canonical,
+                lower=lower,
+                hashsize=hashsize,
+                threads=threads
+            )
+
+            _, genome1_counts = count_kmers_partial(genome1)
+            genome1_counts = genome1_counts[kmer]
+
+            _, genome2_counts = count_kmers_partial(genome2)
+            genome2_counts = genome2_counts[kmer]
+
+            res_acf[kmer] = len(set(genome1_counts.keys()) & set(genome2_counts.keys()))
+
+        else:
+            res_acf[kmer] = len(set(counts[genome1][kmer].keys()) & set(counts[genome2][kmer].keys()))
+
+    res_acf = sorted(res_acf.items(), key=itemgetter(0))
+
+    return res_acf
+
+
+def par_cre(
+    genome: str,
+    kmin: Optional[int] = None,
+    kmax: Optional[int] = None,
+    counts: Optional[Dict[str, Dict[int, jf.Kmercount]]] = None,
+    fast: bool = False,
+    canonical: bool = False,
+    lower: int = 1,
+    hashsize: str = "100M",
+    threads: int = 1
+) -> List[Tuple[int, float]]:
+    """
+    Make the computation of CRE parallel
+    Run a instance of this function for each of the processes in a Pool
+
+    :param genome:      Input genome
+    :param kmin:        Minimum kmer size
+    :param kmax:        Maximum kmer size
+    :param counts:      Kmer counts for the input genomes
+    :param fast:        Jellyfish one-pass calculation (faster)
+    :param canonical:   Jellyfish count only canonical kmers
+    :param lower:       Do not let Jellyfish output kmers with count < --lower
+    :param hashsize:    Jellyfish initial hash size
+    :param threads:     Maximum number of threads for Jellyfish
+    :return:            CRE
+    """
+
+    res_cre = dict()
+
+    def cal_re(a0: jf.Kmercount, a1: jf.Kmercount, a2: jf.Kmercount) -> float:
+        """
+        Calculate Relative Entropy (RE)
+
+        :param a0:  Kmer count with kmer size
+        :param a1:  Kmer count with kmer size - 1
+        :param a2:  Kmer count with kmer size - 2
+        :return:    Relative Entropy
+        """
+
+        result = 0.0
+        rfactor = a0.sum
+        lfactor = math.log((a1.sum ** 2) / (a2.sum * rfactor), 2)
+
+        for key in a0.keys():
+            realf = a0[key]
+            left = a1[key[:-1]] if key[:-1] in a1 else 0
+            right = a1[key[1:]] if key[1:] in a1 else 0
+            below = a2[key[1:-1]] if key[1:-1] in a2 else 0
+
+            if 0 not in (left, right, below):
+                expectf = left * right / below
+                result += max(0, realf / rfactor * (math.log(realf / expectf, 2) + lfactor))
+
+        return result
+
+    a0 = None
+    a1 = None
+    a2 = None
+
+    count_kmers_partial = partial(
+        count_kmers,
+        fast=fast,
+        canonical=canonical,
+        lower=lower,
+        hashsize=hashsize,
+        threads=threads
+    )
+
+    for kmer in range(kmax, kmin - 1, -1):
+        if not counts:
+            if a0 is None and a1 is None and a2 is None:
+                _, a0 = count_kmers_partial(genome, kmin=kmer, kmax=kmer)
+                a0 = a0[kmer]
+
+                _, a1 = count_kmers_partial(genome, kmin=(kmer - 1), kmax=(kmer - 1))
+                a1 = a1[kmer - 1]
+
+                _, a2 = count_kmers_partial(genome, kmin=(kmer - 2), kmax=(kmer - 2))
+                a2 = a2[kmer - 2]
+
+            else:
+                a0 = a1
+                a1 = a2
+
+                _, a2 = count_kmers_partial(genome, kmin=(kmer - 2), kmax=(kmer - 2))
+                a2 = a2[kmer - 2]
+            
+            res_cre[kmer] = cal_re(a0, a1, a2)
+
+        else:
+            res_cre[kmer] = cal_re(counts[genome][kmer], counts[genome][kmer - 1], counts[genome][kmer - 2])
+
+        if kmer + 1 in res_cre:
+            res_cre[kmer] += res_cre[kmer + 1]
+
+    res_cre = sorted(res_cre.items(), key=itemgetter(0))
+
+    return res_cre
+
+
+def par_ofc(
+    kmer: str,
+    genomes: Optional[List[str]] = None,
+    counts: Optional[Dict[str, Dict[str, Dict[str, int]]]] = None,
+    fast: bool = False,
+    canonical: bool = False,
+    lower: int = 1,
+    hashsize: str = "100M",
+    threads: int = 1
+) -> Tuple[int, float]:
+    """
+    Make the computation of OCF parallel
+    Run a instance of this function for each of the processes in a Pool
+
+    :param kmer:        Kmer size
+    :param genomes:     List of input genomes
+    :param counts:      Kmer counts for the input genomes
+    :param fast:        Jellyfish one-pass calculation (faster)
+    :param canonical:   Jellyfish count only canonical kmers
+    :param lower:       Do not let Jellyfish output kmers with count < --lower
+    :param hashsize:    Jellyfish initial hash size
+    :param threads:     Maximum number of threads for Jellyfish
+    :return:            OCF
+    """
+
+    keys = list()
+
+    count_kmers_partial = partial(
+        count_kmers,
+        kmin=kmer,
+        kmax=kmer,
+        fast=fast,
+        canonical=canonical,
+        lower=lower,
+        hashsize=hashsize,
+        threads=threads
+    )
+
+    for genome in genomes:
+        if not counts:
+            _, genome_counts = count_kmers_partial(genome)
+            genome_counts = genome_counts[kmer]
+
+        else:
+            genome_counts = counts[genome][kmer]
+
+        keys.extend(list(genome_counts.keys()))
+
+    count_features = list(collections.Counter((collections.Counter(keys).values())).values())
+    lnp = np.log2(count_features) - (kmer * 2)
+
+    return kmer, np.sum(np.exp2(lnp) * lnp) * -1
+
+
+def optimal_kmer_size(
+    genomes: List[str],
+    closely_related: bool = False,
+    kmin: int = 4,
+    kmax: Optional[int] = None,
+    acf_cutoff: float = 0.1,
+    cre_cutoff: float = 0.1,
+    fast: bool = False,
+    canonical: bool = False,
+    lower: int = 1,
+    hashsize: str = "100M",
+    in_memory: bool = False,
+    nproc: int = 1,
+    threads: int = 1,
+    output: Optional[str] = None
+) -> None:
+    """
+    Compute the Cumulative Relative Entropy (CRE), Average Number of Common Features (ACF),
+    and Observed Common Features on a seti of genomes over a kmer size interval.
+
+    Eventually search for the optimal kmer size.
+
+    :param genomes:         List with paths to the input genomes
+    :param closely_related: Closely related genomes
+    :param kmin:            Minimum kmer size (4 by default; cannot be lower than 4)
+    :param kmax:            Maximum kmer size
+    :param acf_cutoff:      Cutoff to use in selecting kmers whose ACF's are >= (cutoff * max(ACF))
+    :param cre_cutoff:      Cutoff to use in selecting kmers whose CRE's are <= (cutoff * max(CRE))
+    :param fast:            Jellyfish one-pass calculation (faster)
+    :param canonical:       Jellyfish count only canonical kmers
+    :param lower:           Do not let Jellyfish output kmers with count < --lower
+    :param hashsize:        Jellyfish initial hash size
+    :param in_memory:       Keep Jellyfish counts in memory
+    :param nproc:           Maximum number of CPUs to make it parallel
+    :param threads:         Maximum number of threads for Jellyfish
+    :param output:          Path to the output file
+    """
+
+    if output:
+        if os.path.isfile(output):
+            raise Exception("Output file already exists")
+
+        outfolder = os.path.dirname(output)
+
+        if not os.path.isdir(outfolder):
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), outfolder)
+
+    if kmax <= kmin:
+        raise ValueError("Invalid kmer size interval")
+
+    counts = dict()
+
+    if in_memory:
+        print("Counting kmers in {} genomes".format(len(genomes)))
+
+        if len(genomes) < 2:
+            raise Exception("Not enough input genomes")
+
+        with mp.Pool(processes=nproc) as pool, tqdm.tqdm(total=len(genomes)) as pbar:
+            def progress(*args):
+                pbar.update()
+
+            count_kmers_partial = partial(
+                count_kmers,
+                kmin=(kmin - 2),
+                kmax=kmax,
+                fast=fast,
+                canonical=canonical,
+                lower=lower,
+                hashsize=hashsize,
+                threads=threads
+            )
+
+            jobs = [
+                pool.apply_async(
+                    count_kmers_partial,
+                    args=(genome,),
+                    callback=progress,
+                )
+                for genome in genomes
+            ]
+
+            for job in jobs:
+                genome, genome_counts = job.get()
+                counts[genome] = genome_counts
+
+        if not counts:
+            raise Exception("Something went wrong while counting kmer over the input genomes")
+
+    if not closely_related:
+        print("Computing Average number of Common Features (ACF) pairwise")
+
+        acf_results = list()
+
+        genomes_comb = combinations(genomes, 2)
+        genomes_comb_len = int(math.factorial(len(genomes)) / (math.factorial(len(genomes) - 2) * 2))
+
+        with mp.Pool(processes=nproc) as pool, tqdm.tqdm(total=genomes_comb_len) as pbar:
+            def progress(*args):
+                pbar.update()
+
+            compute_acf_partial = partial(
+                par_acf,
+                kmin=kmin,
+                kmax=kmax,
+                counts=counts,
+                fast=fast,
+                canonical=canonical,
+                lower=lower,
+                hashsize=hashsize,
+                threads=threads
+            )
+
+            jobs = [
+                pool.apply_async(
+                    compute_acf_partial,
+                    args=(genome1, genome2,),
+                    callback=progress,
+                )
+                for genome1, genome2 in genomes_comb
+            ]
+
+            for job in jobs:
+                acf_results.append(job.get())
+
+        acf_results = list(chain(*[result for result in acf_results]))
+
+        acf_list = [x[1] for x in acf_results]
+        maxacf = acf_cutoff * float(max(acf_list))
+        acf_kmax = [x[0] for x in acf_results if x[1] >= maxacf]
+        acf_kmax = filter(acf_kmax, genomes_comb_len)
+
+        if acf_kmax:
+            acf_kmax_max = max(acf_kmax)
+            
+            if acf_kmax_max != kmax:
+                print("Redefining kmer size interval: --k-max={}".format(acf_kmax_max))
+
+            kmax = acf_kmax_max
+
+    else:
+        acf_kmax = range(kmin, kmax + 1)
+
+    print("Computing Cumulative Relative Entropy (CRE)")
+
+    cre_results = list()
+
+    with mp.Pool(processes=nproc) as pool, tqdm.tqdm(total=len(genomes)) as pbar:
+        def progress(*args):
+            pbar.update()
+        
+        compute_cre_partial = partial(
+            par_cre,
+            kmin=kmin,
+            kmax=kmax,
+            counts=counts,
+            fast=fast,
+            canonical=canonical,
+            lower=lower,
+            hashsize=hashsize,
+            threads=threads
+        )
+
+        jobs = [
+            pool.apply_async(
+                compute_cre_partial,
+                args=(genome,),
+                callback=progress,
+            )
+            for genome in genomes
+        ]
+
+        for job in jobs:
+            cre_results.append(job.get())
+
+    cre_results = list(chain(*[result for result in cre_results]))
     
+    cre_list = [x[1] for x in cre_results]
+    maxval = 0 if not cre_list else cre_cutoff * float(max(cre_list))
+    cre_kmin = [x[0] for x in cre_results if x[1] < maxval]
+    cre_kmin = filter(cre_kmin, 0)
+
+    if cre_kmin:
+        cre_kmin_min = min(cre_kmin)
+            
+        if cre_kmin_min != kmin:
+            print("Redefining kmer size interval: --k-min={}".format(cre_kmin_min))
+
+        kmin = cre_kmin_min
+
+    print("Computing Observed Common Features (OCF)")
+
+    ofc_results = dict()
+
+    kmer_sizes = list(range(kmin, kmax + 1))
+
+    with mp.Pool(processes=nproc) as pool, tqdm.tqdm(total=len(kmer_sizes)) as pbar:
+        def progress(*args):
+            pbar.update()
+
+        compute_ofc_partial = partial(
+            par_ofc,
+            genomes=genomes,
+            counts=counts,
+            fast=fast,
+            canonical=canonical,
+            lower=lower,
+            hashsize=hashsize,
+            threads=threads
+        )
+
+        jobs = [
+            pool.apply_async(
+                compute_ofc_partial,
+                args=(kmer,),
+                callback=progress,
+            )
+            for kmer in kmer_sizes
+        ]
+
+        for job in jobs:
+            kmer, res = job.get()
+            ofc_results[kmer] = res
+
+    ofc_results = sorted(ofc_results.items(), key=itemgetter(0))
+
+    ofc_list = [x[1] for x in ofc_results]
+
+    if len(ofc_list) != 0:
+        ofc_max = max(ofc_list)
+
+    else:
+        ofc_max = 1e7
+
+    k_max = [x for x, y in ofc_results if y == ofc_max]
+    ofc_possible_kmers = [x[0] for x in ofc_results if x[0] >= k_max[0]]
+
+    opt = list(set(cre_kmin) & set(acf_kmax) & set(ofc_possible_kmers))
+
+    if opt:
+        out_message = "The recommended choice of kmer is: {}".format(min(opt))
+
+    else:
+        out_message = ("The recommended choice of kmer does not lie within the given interval "
+                       "from 4 to the largest kmer length you selected")
+
+    print(out_message, file=open(output, "w+") if output else None)
+
+
+def run(args) -> None:
     # Load command line parameters
     args = read_params(args)
 
-    genomeList = open(args.filenames, "r").read().strip().split("\n")
-    genLen = len(genomeList)
+    t0 = time.time()
 
-    if args.filenames and genLen >=2:
-        combs = combinations(genomeList,2)
-        combLen = float(len(list(combinations(genomeList,2))))
-        xcutoff = args.cre_cutoff
-        ycutoff = args.acf_cutoff
-        outdata_cre = []
-        acf_res = []
-        pool = mp.Pool(processes=args.nproc)
+    optimal_kmer_size(
+        [line.strip() for line in open(args.filenames).readlines() if line.strip()],
+        closely_related=args.closely_related,
+        kmin=args.k_min,
+        kmax=args.k_max,
+        acf_cutoff=args.acf_cutoff,
+        cre_cutoff=args.cre_cutoff,
+        fast=args.fast,
+        canonical=args.canonical,
+        lower=args.lower,
+        hashsize=args.hashsize,
+        in_memory=args.in_memory,
+        nproc=args.nproc,
+        threads=args.threads,
+        output=args.output
+    )
 
-        if args.closely_related:
-            kl = args.klarge
-            acf_kmax2 = range(4, kl+1)
-            pool1 = mp.Pool(processes=args.nproc)
-            for l in range(genLen):
-                outdata_cre.append(pool1.apply_async(kopt_cre, args=(l, kl, genomeList,args)))
-            outdata_cre = list(chain(*[result.get() for result in outdata_cre]))
-            cre = [x[1] for x in outdata_cre]
-            if len(cre) != 0:
-                maxval = xcutoff * float(max(cre))
-            else:
-                maxval = 0
-            result = [x[0] for x in outdata_cre if x[1] < maxval]
-            result2 = filter(result, genLen * 0)
+    t1 = time.time()
 
-            pool1.close()
-            pool1.join()
-            time.sleep(10)
-
-            pool2 = mp.Pool(processes=args.nproc)
-            outdata_ofc = []
-            if len(result2) != 0:
-                ks = min(result2)
-            else:
-                ks = 4
-            for kmer in range(ks, kl+1):
-                outdata_ofc.append(pool2.apply_async(kopt_ofc, args=(genomeList, kmer,args)))
-            outdata_ofc = list(chain(*[result.get() for result in outdata_ofc]))
-            ofc = [x[1] for x in outdata_ofc]
-            if len(ofc) != 0:
-                ofc_max = max(ofc)
-            else:
-                ofc_max = 1e7
-
-            kmax = [x for x,y in outdata_ofc if y==ofc_max]
-            ofc_possible_kmers = [x[0] for x in outdata_ofc if x[0] >= kmax[0]]
-            pool2.close()
-            pool2.join()
-
-        else:
-            for p in combs:
-                acf_res.append(pool.apply_async(kopt_acf, args=(p,args)))
-            acf_res = list(chain(*[result.get() for result in acf_res]))
-            k_acf = [x[0] for x in acf_res]
-            acf = [x[1] for x in acf_res]
-            maxacf = ycutoff * float(max(acf))
-            acf_kmax = [x[0] for x in acf_res if x[1] >= maxacf]
-            acf_kmax2 = filter(acf_kmax, combLen * 0 )
-
-            if len(acf_kmax2) == 0:
-                kl = args.klarge
-            else:
-                kl = max(acf_kmax2)
-
-            pool.close()
-            pool.join()
-            time.sleep(10)
-
-            pool1 = mp.Pool(processes=args.nproc)
-            for l in range(genLen):
-                outdata_cre.append(pool1.apply_async(kopt_cre, args=(l, kl, genomeList,args)))
-            outdata_cre = list(chain(*[result.get() for result in outdata_cre]))
-            cre = [x[1] for x in outdata_cre]
-            if len(cre) != 0:
-                maxval = xcutoff * float(max(cre))
-            else:
-                maxval = 0
-            result = [x[0] for x in outdata_cre if x[1] < maxval]
-            result2 = filter(result, genLen * 0)
-
-            pool1.close()
-            pool1.join()
-            time.sleep(10)
-            
-            pool2 = mp.Pool(processes=args.nproc)
-            outdata_ofc = []
-            if len(result2) != 0:
-                ks = min(result2)
-            else:
-                ks = 4
-            for kmer in range(ks, kl+1):
-                outdata_ofc.append(pool2.apply_async(kopt_ofc, args=(genomeList, kmer,args)))
-            outdata_ofc = list(chain(*[result.get() for result in outdata_ofc]))
-            ofc = [x[1] for x in outdata_ofc]
-            if len(ofc) != 0:
-                ofc_max = max(ofc)
-            else:
-                ofc_max = 1e7
-
-            kmax = [x for x,y in outdata_ofc if y==ofc_max]
-            ofc_possible_kmers = [x[0] for x in outdata_ofc if x[0] >= kmax[0]]
-
-            pool2.close()
-            pool2.join()
-
-    else:
-        return print('list of filenames must be more than 1')
-
-    opt = list(set(result2) & set(acf_kmax2) & set(ofc_possible_kmers))
-
-    if args.output is not None and len(opt)>0:
-        with open(args.output, 'w') as ofhandle:
-            print("The recommended choice of kmer is: ", min(opt), file=ofhandle)
-    
-    elif args.output is not None and len(opt)==0:
-        with open(args.output, 'w') as ofhandle:
-            print(
-                ("The recommended choice of kmer does not lie within the given interval "
-                 "from 4 to the largest kmer length you selected"), 
-                file=ofhandle
-            )
-    
-    elif len(opt) == 0:
-        print(("The recommended choice of kmer does not lie within the given interval "
-               "from 4 to the largest kmer length you selected"))
-
-    else:
-        print("The recommended choice of kmer is: ", min(opt))
+    print("Total elapsed time {}s".format(int(t1 - t0)))
 
 
 if __name__ == "__main__":

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kitsune" %}
-{% set version = "1.3.2" %}
+{% set version = "1.3.3" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This PR contains a major improvement for the `kopt` command and several very minor improvements to all the other modules:

1. The output of all the modules required to be fixed;
2. The `Kmercount` superclass has been changed with `dict` (didn't really make sense to use `collections.Counter` as a superclass since the output of `jellyfish` is already loaded into a dictionary);
3. The whole `kopt` pipeline has been reimplemented following the previous implementation. The main reason why I decided to work on that is because it didn't keep in memory the kmer counts. This behaviour definitely makes sense in case you need to process a lot of genomes over a large kmer size range but you do not have a lot of memory. However, it requires a lot of time. Thus, I added a new flag `--in-memory` that allows to first process all the input genomes, counting for their kmers with `jellyfish` using different kmer sizes, and finally run the pipeline by computing the three metrics ACF, CRE, and OFC. Also, I added a `--k-min` in order to let the user start with a custom minimum kmer size (not necessarily 4).

Finally, I updated the `README.md` according to the new `kopt` implementation and I bumped the version of `kitsune` to 1.3.3.

The version on PyPI must be also updated.

@natapol I would really appreciate if you could have a look at this and eventually merge